### PR TITLE
Fix matplotlib missing fonts directory

### DIFF
--- a/empack/filter_env.py
+++ b/empack/filter_env.py
@@ -24,7 +24,7 @@ pack_config = {
                 {
                     "regex": R"^(?!.*\/tests\/).*((.*.\.py$)|(.*.\.so$))",
                 },
-                {"pattern": "*matplotlibrc"},
+                {"pattern": "**/matplotlib/mpl-data/**"},
             ],
             "exclude_patterns": [],
         },


### PR DESCRIPTION
This fixes Matplotlib support:
![Screenshot from 2022-08-03 10-57-45](https://user-images.githubusercontent.com/21197331/182568131-d8361b55-683b-41a1-88f4-73417e201dbf.png)

