### PR TITLE
Config

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -67,7 +67,20 @@ jobs:
           emsdk activate ${{ matrix.emsdk_ver }}
           source $CONDA_EMSDK_DIR/emsdk_env.sh
 
-          empack pack python core $MAMBA_ROOT_PREFIX/envs/env1 --version=3.10
+          empack pack env \
+            --env-prefix $MAMBA_ROOT_PREFIX/envs/env1 \
+            --outname env_1 \
+            --config $GITHUB_WORKSPACE/tests/empack_test_config.yaml
+
+          if [ ! -f "env_1.js" ]; then
+            echo "env_1.js is missing"
+            exit 1
+          fi
+          if [ ! -f "env_1.data" ]; then
+            echo "env_1.data is missing"
+            exit 1
+          fi
+
 
       - name: Create another lib-only env and pack it up
         shell: bash -l {0}
@@ -77,4 +90,31 @@ jobs:
           emsdk activate ${{ matrix.emsdk_ver }}
           source $CONDA_EMSDK_DIR/emsdk_env.sh
 
-          empack pack python core $MAMBA_ROOT_PREFIX/envs/env2 --version=3.10
+          empack pack env \
+            --env-prefix $MAMBA_ROOT_PREFIX/envs/env2 \
+            --outname env_2 \
+            --config $GITHUB_WORKSPACE/tests/empack_test_config.yaml
+
+          if [ ! -f "env_2.js" ]; then
+            echo "env_2.js is missing"
+            exit 1
+          fi
+          if [ ! -f "env_2.data" ]; then
+            echo "env_2.data is missing"
+            exit 1
+          fi
+
+
+          empack pack env \
+            -c $GITHUB_WORKSPACE/tests/empack_test_config.yaml \
+            -e $MAMBA_ROOT_PREFIX/envs/env2 \
+            -o env_2_b \
+
+          if [ ! -f "env_2_b.js" ]; then
+            echo "env_2_b.js is missing"
+            exit 1
+          fi
+          if [ ! -f "env_2_b.data" ]; then
+            echo "env_2_b.data is missing"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ pip install empack
 
 ## Usage
 
-You can pack the Python 3.10 environment (located at `/path/to/env`) with the following command:
+You can pack the  environment (located at `/path/to/env`) with the following command:
 
 ```bash
-empack pack python core /path/to/env --version=3.10
+empack pack env --env-prefix /path/to/env --outname python_data  --config /path/to/config.yaml
 ```
 
 This will generate two files `python_data.js` and `python_data.data` that you can use in the browser.
+A sample config is located in [`tests/empack_test_config.yaml`](https://github.com/emscripten-forge/empack/blob/main/tests/empack_test_config.yaml)

--- a/empack/file_patterns.py
+++ b/empack/file_patterns.py
@@ -1,7 +1,8 @@
 import fnmatch
 import re
-from typing import List, Union, Dict
+from typing import Dict, List, Union
 
+import yaml
 from pydantic import BaseModel, Extra, Field, PrivateAttr
 
 
@@ -61,3 +62,11 @@ class PkgFileFilter(BaseModel, extra=Extra.forbid):
     def match(self, pkg_name, path):
         matcher = self.packages.get(pkg_name, self.default)
         return matcher.match(path)
+
+
+def pkg_file_filter_from_yaml(path):
+
+    with open(path, "r") as pack_config_file:
+        pack_config = yaml.safe_load(pack_config_file)
+        pkg_file_filter = PkgFileFilter.parse_obj(pack_config)
+    return pkg_file_filter

--- a/tests/empack_test_config.yaml
+++ b/tests/empack_test_config.yaml
@@ -1,0 +1,27 @@
+packages:
+  python-dateutil:
+    include_patterns:
+      - regex: '^(?!.*\/tests\/).*(.*.\.py$)|(.*.\.so$)|(.*dateutil-zoneinfo\.tar\.gz$)'
+  matplotlib:
+    include_patterns:
+      - regex: '^(?!.*\/tests\/).*(.*.\.py$)|(.*.\.so$)'
+      - pattern: "*matplotlibrc"
+
+  scikit-learn:
+    include_patterns:
+      - regex: '^(?!.*\/tests\/).*(.*.\.py$)|(.*.\.so$)'
+      - pattern: "**/sklearn/datasets/**"
+
+  scikit-image:
+    include_patterns:
+      - regex: '^(?!.*\/tests\/).*(.*.\.py$)|(.*.\.so$)'
+      - pattern: "**/skimage/data/**"
+
+
+default:
+  include_patterns:
+    - pattern: '*.so'
+    - pattern: '*.py'
+  exclude_patterns:
+    - pattern: '**/tests/**/*.py'
+    - pattern: '**/tests/**/*.so'

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,4 @@
-from empack.file_patterns import FileFilter, FilePattern, PkgFileFilter
-from empack.filter_env import pack_config
+from empack.file_patterns import FileFilter, FilePattern, pkg_file_filter_from_yaml
 
 
 def test_regex_pattern():
@@ -73,25 +72,24 @@ def test_dataset_filter():
     assert not fp.match("/home/fu/sxklearn/datasets/some/folder.txt")
 
 
-def test_default():
+def test_from_yaml():
+    import os
 
-    FileFilter.parse_obj(pack_config["default"])
-    for _pkg_name, conf in pack_config["packages"].items():
-        FileFilter.parse_obj(conf)
+    dn = os.path.dirname(os.path.realpath(__file__))
+    config_path = os.path.join(dn, "empack_test_config.yaml")
+    pkg_file_filter = pkg_file_filter_from_yaml(config_path)
 
-
-def test_default_pkg_filter():
-    f = PkgFileFilter.parse_obj(pack_config)
-    assert f.match(pkg_name="fubar", path="/home/fu/bar.py")
-    assert f.match(pkg_name="fubar", path="/home/fu/bar.so")
-    assert not f.match(pkg_name="fubar", path="/home/tests/fu/bar.py")
-    assert not f.match(pkg_name="fubar", path="/home/tests/fu/bar.so")
-    assert f.match(pkg_name="fubar", path="/hometests/fu/bar.py")
-    assert f.match(pkg_name="fubar", path="/hometests/fu/bar.so")
+    assert pkg_file_filter.match(pkg_name="fubar", path="/home/fu/bar.py")
+    assert pkg_file_filter.match(pkg_name="fubar", path="/home/fu/bar.so")
+    assert not pkg_file_filter.match(pkg_name="fubar", path="/home/tests/fu/bar.py")
+    assert not pkg_file_filter.match(pkg_name="fubar", path="/home/tests/fu/bar.so")
+    assert pkg_file_filter.match(pkg_name="fubar", path="/hometests/fu/bar.py")
+    assert pkg_file_filter.match(pkg_name="fubar", path="/hometests/fu/bar.so")
 
 
 if __name__ == "__main__":
     import sys
+
     import pytest
 
     retcode = pytest.main()


### PR DESCRIPTION
This has breaking changes!

Changes:
* removed deprecated `empack pack python core ...` cli/methods and replaced them with `empack pack env ...`
* removed the "in-code" default config and any attempts to provide a default config. The cli-command `empack pack env` expects a path to a YAML config file. This might seem annoying, but any default config we could host here would be outdated soon and against the spirit of this PR
* in the file-including/file-excluding code, I use the high level [PkgFileFilter](https://github.com/emscripten-forge/empack/blob/bba8a7c842c02ee13c6f5425accfa0e63efd121b/empack/file_patterns.py#L57) and the respective [match](https://github.com/emscripten-forge/empack/blob/bba8a7c842c02ee13c6f5425accfa0e63efd121b/empack/file_patterns.py#L61) method instead of doing this by hand
* extended the ci to check if empack produces the files (just check for their existence)

Other Repos Need to:
* introduce a config.yaml file and pass them to the cli / python-API 

We  should put the config in https://github.com/emscripten-forge/recipes and `xeus-lite` can fetch the config from there
