### PR TITLE
changed empack file packaging schema st a list is also valid

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -126,7 +126,7 @@ jobs:
           empack pack env \
             -c $GITHUB_WORKSPACE/tests/empack_test_config.yaml \
             -e $MAMBA_ROOT_PREFIX/envs/env2 \
-            -o env_2_b \
+            -o env_2_b 
 
           if [ ! -f "env_2_b.js" ]; then
             echo "env_2_b.js is missing"

--- a/empack/file_packager.py
+++ b/empack/file_packager.py
@@ -188,13 +188,11 @@ def split_pack_environment(
 
     # name of the env
     env_name = PurePath(env_prefix).parts[-1]
-    print(env_name)
     js_files = []
     for pkg_meta in iterate_env_pkg_meta(env_prefix):
 
         pkg_outname = pkg_meta["fn"][:-8]
         pkg_name = pkg_meta["name"]
-        print(pkg_name)
 
         matchers = pkg_file_filter.get_matchers(pkg_name=pkg_name)
 

--- a/empack/file_packager.py
+++ b/empack/file_packager.py
@@ -13,7 +13,7 @@ import typer
 
 from .extend_js import extend_js
 from .file_patterns import PkgFileFilter
-from .filter_env import filter_env, filter_pkg, iterate_env_pkg_meta
+from .filter_env import filter_env, iterate_env_pkg_meta, split_filter_pkg
 
 EMSDK_VER = "latest"
 
@@ -48,7 +48,7 @@ def download_and_setup_emsdk(emsdk_version):
         if tags.ok and tags.content:
             tag = json.loads(tags.content)[0]["name"]
         else:
-            tag = '3.1.2'
+            tag = "3.1.2"
     else:
         tag = emsdk_version
 
@@ -189,45 +189,62 @@ def split_pack_environment(
     # name of the env
     env_name = PurePath(env_prefix).parts[-1]
     print(env_name)
-
-    all_pks = []
+    js_files = []
     for pkg_meta in iterate_env_pkg_meta(env_prefix):
 
         pkg_outname = pkg_meta["fn"][:-8]
+        pkg_name = pkg_meta["name"]
+        print(pkg_name)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            target_dir = os.path.join(temp_dir, env_name)
-            os.makedirs(target_dir)
+        matchers = pkg_file_filter.get_matchers(pkg_name=pkg_name)
 
-        has_any_file = filter_pkg(
-            env_prefix=env_prefix,
-            pkg_meta=pkg_meta,
-            target_dir=target_dir,
-            pkg_file_filter=pkg_file_filter,
-        )
-        if has_any_file:
-            all_pks.append(pkg_outname)
-            emscripten_file_packager(
-                outname=pkg_outname,
-                to_mount=env_name,
-                mount_path=env_prefix,
-                export_name=export_name,
-                use_preload_plugins=True,
-                no_node=export_name.startswith("globalThis"),
-                lz4=True,
-                cwd=str(temp_dir),
-                download_emsdk=download_emsdk,
+        with tempfile.TemporaryDirectory() as temp_root_dir:
+
+            temp_dirs = []
+            target_dirs = []
+            for i in range(len(matchers)):
+                temp_dir = os.path.join(temp_root_dir, f"{i}")
+                target_dir = os.path.join(temp_dir, env_name)
+                os.makedirs(target_dir)
+                temp_dirs.append(temp_dir)
+                target_dirs.append(target_dir)
+
+            has_any_files = split_filter_pkg(
+                env_prefix=env_prefix,
+                pkg_meta=pkg_meta,
+                target_dirs=target_dirs,
+                matchers=matchers,
             )
 
-            shutil.copy(os.path.join(str(temp_dir), f"{pkg_outname}.data"), pack_outdir)
-            shutil.copy(os.path.join(str(temp_dir), f"{pkg_outname}.js"), pack_outdir)
+            for i in range(len(matchers)):
+                if has_any_files[i]:
+                    emscripten_file_packager(
+                        outname=f"{pkg_outname}.{i}",
+                        to_mount=env_name,
+                        mount_path=env_prefix,
+                        export_name=export_name,
+                        use_preload_plugins=True,
+                        no_node=export_name.startswith("globalThis"),
+                        lz4=True,
+                        cwd=str(temp_dirs[i]),
+                        download_emsdk=download_emsdk,
+                    )
+                    js_files.append(f"{pkg_outname}.{i}.js")
+                    shutil.copy(
+                        os.path.join(str(temp_dirs[i]), f"{pkg_outname}.{i}.data"),
+                        pack_outdir,
+                    )
+                    shutil.copy(
+                        os.path.join(str(temp_dirs[i]), f"{pkg_outname}.{i}.js"),
+                        pack_outdir,
+                    )
 
-            extend_js(os.path.join(pack_outdir, f"{pkg_outname}.js"))
+                    extend_js(os.path.join(pack_outdir, f"{pkg_outname}.{i}.js"))
 
     # create the base js file
     lines = []
-    for pkg_outname in all_pks:
-        lines.append(f"    promises.push(import('./{pkg_outname}.js'));")
+    for js_file in js_files:
+        lines.append(f"    promises.push(import('./{js_file}'));")
     txt = "\n".join(lines)
     js_import_all_func = f"""export default async function(){{
     let promises = [];

--- a/empack/file_patterns.py
+++ b/empack/file_patterns.py
@@ -56,12 +56,21 @@ class FileFilter(BaseModel, extra=Extra.forbid):
 
 
 class PkgFileFilter(BaseModel, extra=Extra.forbid):
-    packages: Dict[str, FileFilter]
+    packages: Dict[str, Union[FileFilter, List[FileFilter]]]
     default: FileFilter
 
-    def match(self, pkg_name, path):
-        matcher = self.packages.get(pkg_name, self.default)
-        return matcher.match(path)
+    # def match(self, pkg_name, path):
+    #     matcher = self.packages.get(pkg_name, self.default)
+    #     return matcher.match(path)
+
+    def get_matcher(self, pkg_name):
+        return self.packages.get(pkg_name, self.default)
+
+    def get_matchers(self, pkg_name):
+        matchers = self.get_matcher(pkg_name)
+        if not isinstance(matchers, list):
+            matchers = [matchers]
+        return matchers
 
     def merge(self, *others):
         for other in others:
@@ -76,7 +85,7 @@ class PkgFileFilter(BaseModel, extra=Extra.forbid):
 # must be optional for the additional configs, otherwise
 # the would always overwrite the main default config
 class AdditionalPkgFileFilter(BaseModel, extra=Extra.forbid):
-    packages: Dict[str, FileFilter]
+    packages: Dict[str, Union[FileFilter, List[FileFilter]]]
     default: Optional[FileFilter]
 
 

--- a/empack/file_patterns.py
+++ b/empack/file_patterns.py
@@ -59,10 +59,6 @@ class PkgFileFilter(BaseModel, extra=Extra.forbid):
     packages: Dict[str, Union[FileFilter, List[FileFilter]]]
     default: FileFilter
 
-    # def match(self, pkg_name, path):
-    #     matcher = self.packages.get(pkg_name, self.default)
-    #     return matcher.match(path)
-
     def get_matcher(self, pkg_name):
         return self.packages.get(pkg_name, self.default)
 

--- a/tests/empack_test_extra_config.yaml
+++ b/tests/empack_test_extra_config.yaml
@@ -8,5 +8,7 @@ packages:
     - include_patterns:
       - pattern: '**/core'
     - include_patterns:
+      - pattern: '**/sparse'
+    - include_patterns:
       - pattern: '**'
 

--- a/tests/empack_test_extra_config.yaml
+++ b/tests/empack_test_extra_config.yaml
@@ -2,3 +2,11 @@ packages:
   scikit-image:
     exclude_patterns:
       - pattern: '**'
+
+
+  scipy:
+    - include_patterns:
+      - pattern: '**/core'
+    - include_patterns:
+      - pattern: '**'
+

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -79,14 +79,30 @@ def test_from_yaml():
     config_path = os.path.join(dn, "empack_test_config.yaml")
     pkg_file_filter = pkg_file_filter_from_yaml(config_path)
 
-    assert pkg_file_filter.match(pkg_name="fubar", path="/home/fu/bar.py")
-    assert pkg_file_filter.match(pkg_name="fubar", path="/home/fu/bar.so")
-    assert not pkg_file_filter.match(pkg_name="fubar", path="/home/tests/fu/bar.py")
-    assert not pkg_file_filter.match(pkg_name="fubar", path="/home/tests/fu/bar.so")
-    assert pkg_file_filter.match(pkg_name="fubar", path="/hometests/fu/bar.py")
-    assert pkg_file_filter.match(pkg_name="fubar", path="/hometests/fu/bar.so")
-    assert pkg_file_filter.match(pkg_name="scikit-image", path="/home/fu/bar.py")
-    assert pkg_file_filter.match(pkg_name="scikit-image", path="/home/fu/bar.so")
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/fu/bar.py"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/fu/bar.so"
+    )
+    assert not pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/tests/fu/bar.py"
+    )
+    assert not pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/tests/fu/bar.so"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/hometests/fu/bar.py"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/hometests/fu/bar.so"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="scikit-image")[0].match(
+        path="/home/fu/bar.py"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="scikit-image")[0].match(
+        path="/home/fu/bar.so"
+    )
 
 
 def test_from_yaml_with_multiple():
@@ -97,14 +113,30 @@ def test_from_yaml_with_multiple():
     extra_config_path = os.path.join(dn, "empack_test_extra_config.yaml")
     pkg_file_filter = pkg_file_filter_from_yaml(config_path, extra_config_path)
 
-    assert pkg_file_filter.match(pkg_name="fubar", path="/home/fu/bar.py")
-    assert pkg_file_filter.match(pkg_name="fubar", path="/home/fu/bar.so")
-    assert not pkg_file_filter.match(pkg_name="fubar", path="/home/tests/fu/bar.py")
-    assert not pkg_file_filter.match(pkg_name="fubar", path="/home/tests/fu/bar.so")
-    assert pkg_file_filter.match(pkg_name="fubar", path="/hometests/fu/bar.py")
-    assert pkg_file_filter.match(pkg_name="fubar", path="/hometests/fu/bar.so")
-    assert not pkg_file_filter.match(pkg_name="scikit-image", path="/home/fu/bar.py")
-    assert not pkg_file_filter.match(pkg_name="scikit-image", path="/home/fu/bar.so")
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/fu/bar.py"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/fu/bar.so"
+    )
+    assert not pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/tests/fu/bar.py"
+    )
+    assert not pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/home/tests/fu/bar.so"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/hometests/fu/bar.py"
+    )
+    assert pkg_file_filter.get_matchers(pkg_name="fubar")[0].match(
+        path="/hometests/fu/bar.so"
+    )
+    assert not pkg_file_filter.get_matchers(pkg_name="scikit-image")[0].match(
+        path="/home/fu/bar.py"
+    )
+    assert not pkg_file_filter.get_matchers(pkg_name="scikit-image")[0].match(
+        path="/home/fu/bar.so"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We need to split large packages st. the `*.data` files are below 20 MB. 
This allows the packages to be hosted on jdelivr. (which we usefull for `picomamba`)

This allows smth like to split scipy up into three `*.js/*.data` files.  Note that in this case last `include_patterns` catches everything that was not yet included by the above patterns.
```YAML
  scipy:
    - include_patterns:
      - pattern: '**/core'
    - include_patterns:
      - pattern: '**/sparse'
    - include_patterns:
      - pattern: '**'

```
The non-list schema is still valid, ie the following is still valid
```YAML
  fubar:
    include_patterns:
      - pattern: '**/core'
```

We need this hack for `scipy` and bokeh atm. but there might be more packages where such a splitting is desired.

When we use empack without the `--split` argument, we "merge" all the patterns into a single one again (ie we just ask if any of the patterns in the list is including a certain file) 