### PR TITLE
check if `emsdk.__file__`  is None before usage

### DIFF
--- a/empack/file_packager.py
+++ b/empack/file_packager.py
@@ -68,7 +68,8 @@ def get_file_packager_path():
     try:
         import emsdk
 
-        emsdk_dir = Path(emsdk.__file__).parent
+        if emsdk.__file__ is not None:
+            emsdk_dir = Path(emsdk.__file__).parent
     except ImportError:
         pass
 
@@ -412,7 +413,7 @@ def pack_directory(
         temp_dir_str = str(temp_dir)
 
         os.makedirs(os.path.join(temp_dir_str, "assets"), exist_ok=False)
-        assets_dir = os.path.join(temp_dir_str, "assets") 
+        assets_dir = os.path.join(temp_dir_str, "assets")
         shutil.copytree(directory, assets_dir, dirs_exist_ok=True)
 
         emscripten_file_packager(
@@ -429,7 +430,6 @@ def pack_directory(
 
         shutil.copy(os.path.join(temp_dir_str, f"{outname}.data"), os.getcwd())
         shutil.copy(os.path.join(temp_dir_str, f"{outname}.js"), os.getcwd())
-
 
 
 def create_env(pkg_name: str, prefix: str, platform: str, channels=None):


### PR DESCRIPTION
Added a check to see if `emsdk.__file__`  is None before usage.
This was needed when `emsdk` was not installed via conda 