### PR TITLE
Do not filter out zoneinfo shared data

### DIFF
--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -104,6 +104,7 @@ default:
     - pattern: '*.so'
     - pattern: '*.py'
     - pattern: '*.json'
+    - pattern: 'share/zoneinfo/**'
   exclude_patterns:
     - pattern: '**/tests/**/*.py'
     - pattern: '**/tests/**/*.so'


### PR DESCRIPTION
Should fix https://github.com/jupyterlite/xeus-python-demo/issues/7 !