### PR TITLE
removing "{export_name}.importPackages = importPackages" in branch

### DIFF
--- a/empack/file_packager.py
+++ b/empack/file_packager.py
@@ -242,7 +242,7 @@ def split_pack_environment(
             }}
             """
         else:
-            js_function_source = f"""async function importPackages{{
+            js_function_source = f"""async function importPackages(){{
                 {function_body}
             }}
             {export_name}.importPackages = importPackages;
@@ -253,7 +253,7 @@ def split_pack_environment(
         js_function_source = f"""async function importPackages(){{
             {function_body}
         }}
-        module.exports = importPackages
+        module.exports = importPackages;
         """
 
     with open(os.path.join(pack_outdir, f"{outname}.js"), "w") as f:

--- a/empack/file_packager.py
+++ b/empack/file_packager.py
@@ -231,26 +231,33 @@ def split_pack_environment(
 
     lines.append("}")
 
-    txt = "\n".join(lines)
+    function_body = "\n".join(lines)
 
+
+    # browser
     if export_name.startswith("globalThis"):
-        kw = ["","export default"][int(with_export_default_statement)]
-        fname = [" importPackages", ""][int(with_export_default_statement)]
-        js_import_all_func = f"""
-{kw} async function{fname}(){{
-{txt}
-}}
-{export_name}.importPackages = importPackages;
-        """
+        if with_export_default_statement:
+            js_function_source = f"""export default async function(){{
+                {function_body}
+            }}
+            """
+        else:
+            js_function_source = f"""async function importPackages{{
+                {function_body}
+            }}
+            {export_name}.importPackages = importPackages;
+            """
+    # node
     else:
-        js_import_all_func = f"""async function importPackages(){{
-{txt}
-}}
-module.exports = importPackages
+
+        js_function_source = f"""async function importPackages(){{
+            {function_body}
+        }}
+        module.exports = importPackages
         """
 
     with open(os.path.join(pack_outdir, f"{outname}.js"), "w") as f:
-        f.write(js_import_all_func)
+        f.write(js_function_source)
 
 
 def pack_repodata(


### PR DESCRIPTION
The part `{export_name}.importPackages = importPackages;` was in the branch `with_export_default_statement` where we do not have the function/symbol `importPackages`. (the function has no name in that case, since its the `export default` function