### PR TITLE
Add `include_pattern` rule for `itables`

### DIFF
--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -130,8 +130,8 @@ packages:
   itables:
     include_patterns:
       - pattern: '*.py'
-      - pattern: '**/html/**'
-      - pattern: '**/external/**'
+      - pattern: 'html/**'
+      - pattern: 'external/**'
 default:
   include_patterns:
     - pattern: '*.so'

--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -129,7 +129,9 @@ packages:
       - pattern: '**/so'
   itables:
     include_patterns:
-      - pattern: '**/html/**'
+      - pattern: 'html/**/*'
+      - pattern: 'external/**/*'
+      - pattent: '*.py'
 default:
   include_patterns:
     - pattern: '*.so'

--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -131,7 +131,7 @@ packages:
     include_patterns:
       - pattern: 'html/**/*'
       - pattern: 'external/**/*'
-      - pattent: '*.py'
+      - pattern: '*.py'
 default:
   include_patterns:
     - pattern: '*.so'

--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -127,6 +127,9 @@ packages:
   zlib:
     exclude_patterns:
       - pattern: '**/so'
+  itables:
+    include_patterns:
+      - pattern: '**/html/**'
 default:
   include_patterns:
     - pattern: '*.so'

--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -129,9 +129,9 @@ packages:
       - pattern: '**/so'
   itables:
     include_patterns:
-      - pattern: 'html/**/*'
-      - pattern: 'external/**/*'
       - pattern: '*.py'
+      - pattern: '**/html/**'
+      - pattern: '**/external/**'
 default:
   include_patterns:
     - pattern: '*.so'


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/xeus-python-kernel/issues/126

Otherwise the `itables` fails at import because some files are missing.