### PR TITLE
Fix link to the `pyjs-code-runner` repo

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install pyjs-code-runner
         shell: bash -l {0}
         run: |
-          python -m pip install git+https://github.com/DerThorsten/pyjs-code-runner@relocate_env   --no-deps --ignore-installed
+          python -m pip install git+https://github.com/emscripten-forge/pyjs-code-runner --no-deps --ignore-installed
 
       - name: Run pytest
         shell: bash -l {0}


### PR DESCRIPTION
This should fix CI as noticed in #68 

Looks like CI is failing because the `relocate_env` branch has now been deleted: https://github.com/emscripten-forge/pyjs-code-runner/pull/5

So we should be fine cloning the upstream repo directly now.