### PR TITLE
add/append file to exiting packaged meta

### DIFF
--- a/empack/cli/pack.py
+++ b/empack/cli/pack.py
@@ -4,7 +4,13 @@ from typing import Optional
 import typer
 
 from empack.file_patterns import pkg_file_filter_from_yaml
-from empack.pack import DEFAULT_CONFIG_PATH, pack_env
+from empack.pack import (
+    DEFAULT_CONFIG_PATH,
+    add_tarfile_to_env_meta,
+    pack_directory,
+    pack_env,
+    pack_file,
+)
 
 from .app import app
 
@@ -70,3 +76,94 @@ def pack_env_cli(
         use_cache=use_cache,
         compresslevel=compresslevel,
     )
+
+
+# pack directory
+@pack_app.command(name="dir", help="""Pack a directory into a tarball:""")
+def pack_dir_cli(
+    host_dir: Path = typer.Option(  # noqa: B008
+        ...,
+        "--host-dir",
+        "-d",
+        help="path of the directory in host filesystem",
+    ),
+    mount_dir: Path = typer.Option(  # noqa: B008
+        ...,
+        "--mount-dir",
+        "-m",
+        help="path of the directory in the the virtual filesystem",
+    ),
+    outname: Path = typer.Option(  # noqa: B008
+        ...,
+        "--outname",
+        "-o",
+        help="name of the output tarball",
+    ),
+    outdir: Path = typer.Option(  # noqa: B008
+        None,
+        "--outdir",
+        "-o",
+        help="if no output directory is specified the current workdir is used",
+    ),
+):
+    pack_directory(
+        host_dir=host_dir,
+        mount_dir=mount_dir,
+        outname=outname,
+        outdir=outdir,
+    )
+
+
+# pack file
+@pack_app.command(name="file", help="""Pack a directory into a tarball:""")
+def pack_file_cli(
+    host_file: Path = typer.Option(  # noqa: B008
+        ...,
+        "--host-file",
+        "-d",
+        help="path of the file in host filesystem",
+    ),
+    mount_dir: Path = typer.Option(  # noqa: B008
+        ...,
+        "--mount-dir",
+        "-m",
+        help="path of the directory in the the virtual filesystem",
+    ),
+    outname: Path = typer.Option(  # noqa: B008
+        ...,
+        "--outname",
+        "-o",
+        help="name of the output tarball",
+    ),
+    outdir: Path = typer.Option(  # noqa: B008
+        None,
+        "--outdir",
+        "-o",
+        help="if no output directory is specified the current workdir is used",
+    ),
+):
+    pack_file(
+        host_file=host_file,
+        mount_dir=mount_dir,
+        outname=outname,
+        outdir=outdir,
+    )
+
+
+# new command to append to existing tarballs
+@pack_app.command(name="append", help="""Append tarballs to a packaged environment""")
+def append_to_env_cli(
+    env_meta: Path = typer.Option(  # noqa: B008
+        ...,
+        "--env-meta",
+        "-e",
+        help="path of the env meta file (or the directory containing it)",
+    ),
+    tarfile: Path = typer.Option(  # noqa: B008
+        ...,
+        "--tarfile",
+        "-t",
+        help="path of the tarfile to append",
+    ),
+):
+    add_tarfile_to_env_meta(env_meta_filename=env_meta, tarfile=tarfile)

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -135,7 +135,7 @@ def add_tarfile_to_env_meta(env_meta_filename, tarfile):
     with open(env_meta_filename) as f:
         env_meta = json.load(f)
 
-    if env_meta.prefix != "/":
+    if env_meta["prefix"] != "/":
         raise RuntimeError(
             "adding tarfile to env meta file only supported environments with prefix '/'"
         )

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -135,6 +135,11 @@ def add_tarfile_to_env_meta(env_meta_filename, tarfile):
     with open(env_meta_filename) as f:
         env_meta = json.load(f)
 
+    if env_meta.prefix != "/":
+        raise RuntimeError(
+            "adding tarfile to env meta file only supported environments with prefix '/'"
+        )
+
     tarfile_name = Path(tarfile).name
     package_item = {"name": tarfile_name, "filename": tarfile_name}
     # check that the package is not already in the list

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -127,6 +127,36 @@ def pack_pkg(
     return pkg_fname, used_cache
 
 
+def add_tarfile_to_env_meta(env_meta_filename, tarfile):
+    # if is dir
+    if Path(env_meta_filename).is_dir():
+        env_meta_filename = Path(env_meta_filename) / "empack_env_meta.json"
+
+    with open(env_meta_filename) as f:
+        env_meta = json.load(f)
+
+    tarfile_name = Path(tarfile).name
+    package_item = {"name": tarfile_name, "filename": tarfile_name}
+    # check that the package is not already in the list
+    for pkg in env_meta["packages"]:
+        if pkg["filename"] == tarfile_name:
+            msg = f"package with filename '{tarfile_name}' already in env meta file"
+            raise RuntimeError(msg)
+        if pkg["name"] == package_item["name"]:
+            msg = f"package with name '{package_item['name']}' already in env meta file"
+            raise RuntimeError(msg)
+
+    env_meta["packages"].append(package_item)
+    with open(env_meta_filename, "w") as f:
+        json.dump(env_meta, f, indent=4)
+
+    # dir of env_meta_filename
+    env_meta_dir = Path(env_meta_filename).parent
+    # copy tarfile to env_meta_dir if not already there
+    if Path(tarfile).parent != env_meta_dir:
+        shutil.copy(tarfile, env_meta_dir)
+
+
 def pack_env(
     env_prefix,
     relocate_prefix,
@@ -136,6 +166,7 @@ def pack_env(
     compression_format=ALLOWED_FORMATS[0],
     compresslevel=9,
     outdir=None,
+    append_to_existing=False,
 ):
     with TemporaryDirectory() as tmp_dir:
         #  filter the complete environment
@@ -179,6 +210,7 @@ def pack_env(
         empack_env_meta_filename = "empack_env_meta.json"
         if outdir is not None:
             empack_env_meta_filename = Path(outdir) / empack_env_meta_filename
+            # write the file
         with open(empack_env_meta_filename, "w") as f:
             json.dump(env_meta, f, indent=4)
 

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -171,7 +171,6 @@ def pack_env(
     compression_format=ALLOWED_FORMATS[0],
     compresslevel=9,
     outdir=None,
-    append_to_existing=False,
 ):
     with TemporaryDirectory() as tmp_dir:
         #  filter the complete environment

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from typer.testing import CliRunner
 
@@ -44,3 +46,54 @@ class TestCLI:
 
         result = runner.invoke(app, args)
         assert result.exit_code == 0
+
+        # create a directory with some files
+        dir_name = "test_dir"
+        dir_path = tmp_path / dir_name
+        dir_path.mkdir()
+        file1 = dir_path / "file1.txt"
+        file1.write_text("file1")
+
+        args = [
+            "pack",
+            "dir",
+            "--host-dir",
+            str(dir_path),
+            "--mount-dir",
+            "/",
+            "--outname",
+            "packaged_dir.tar.gz",
+            "--outdir",
+            str(tmp_path),
+        ]
+        result = runner.invoke(app, args)
+        assert result.exit_code == 0
+
+        # append the directory to the env
+        args = [
+            "pack",
+            "append",
+            "--env-meta",
+            str(tmp_path),
+            "--tarfile",
+            str(tmp_path / "packaged_dir.tar.gz"),
+        ]
+        result = runner.invoke(app, args)
+        print(result.stdout)
+        assert result.exit_code == 0
+
+        # check that there is a json with all the packages
+        env_metadata_json_path = tmp_path / "empack_env_meta.json"
+        assert env_metadata_json_path.exists()
+
+        with open(env_metadata_json_path) as f:
+            env_meta = json.load(f)
+        packages = env_meta["packages"]
+        env_meta_dict = dict()
+
+        for pkg in packages:
+            env_meta_dict[pkg["name"]] = pkg
+
+        assert "packaged_dir.tar.gz" in env_meta_dict
+        assert "numpy" in env_meta_dict
+        assert "python" in env_meta_dict


### PR DESCRIPTION
This allows to add files and dirs (packed as tarfile)  to a packaged environment.
The workflow is:
```bash

# pack the env itself
empack pack env \
     --env-prefix /some/env  \
     --outdir outdir

# pack directory
empack pack dir \
    --host-dir /the/extra/dir \ 
    --mount-dir /dir/in/virtual/filesystem \ 
    --outname extra_dir.tar.gz \ 
    --outdir outdir

# include the extra directory in the packed env 
empack pack append \
   --env-meta outdir    \
   --tarfile outdir/extra_dir.tar.gz


# pack an extra file
empack pack file \
    --host-file /the/extra/file.png \ 
    --mount-dir /dir/in/virtual/filesystem \ 
    --outname file_png.tar.gz \ 
    --outdir outdir

# include the extra dir in the packed env 
empack pack append \
   --env-meta outdir    \
   --tarfile outdir/file_png.tar.gz
```