### PR TITLE
Add Include/Exclude Patterns for `pint` Package to `empack_config` (#2)

### DIFF
--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -157,6 +157,14 @@ packages:
     include_patterns:
       - pattern: '*.py'
       - pattern: '*.html'
+  pint:
+     include_patterns:
+       - pattern: '*.so'
+       - pattern: '*.py'
+       - pattern: '*.txt'
+     exclude_patterns:
+       - pattern: '**/tests/**/*.py'
+       - pattern: '**/tests/**/*.so'
 default:
   include_patterns:
     - pattern: '*.so'


### PR DESCRIPTION
This follows advice by @martinRenou provided in 

https://github.com/jupyterlite/xeus-python-kernel/issues/79#issuecomment-1244990930

and should close 

https://github.com/jupyter-xeus/xeus-python/issues/603

(and by extension)

https://github.com/brightway-lca/brightway-live/issues/52

> [!NOTE]
> This was first added to `recipes/empack_config.yaml`, which is a historical artefact according to the discussion here: https://github.com/emscripten-forge/recipes/pull/1047#event-12876884732