### PR TITLE
Fix backward compat on config files

### DIFF
--- a/empack/file_patterns.py
+++ b/empack/file_patterns.py
@@ -21,7 +21,7 @@ class UnixPattern:
 
 
 class FileFilter:
-    def __init__(self, exclude_patterns=None):
+    def __init__(self, include_patterns=None, exclude_patterns=None):
         def patter_from_dict(**d):
             if "pattern" in d:
                 return UnixPattern(**d)

--- a/tests/empack_test_config.yaml
+++ b/tests/empack_test_config.yaml
@@ -1,4 +1,6 @@
 default:
+  include_patterns:
+    - pattern: '**/*.py'
   exclude_patterns:
     - pattern: '**/*.pyc'
     - pattern: '**/tests/**/*.py'


### PR DESCRIPTION
Even though we'll make an 4.0.0 major release, we should be a bit user-friendly and keep accepting `include_patterns` even though it's not used