### PR TITLE
Undo removal of include dirs for allowing kernels to access headers

### DIFF
--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -13,8 +13,6 @@ packages:
       - pattern: '**'
 default:
   exclude_patterns:
-    - pattern: 'include/**'
-    - pattern: '**/include/**'
     - pattern: 'bin/**'
     - pattern: '**/bin/**'
     - pattern: 'tests/**'


### PR DESCRIPTION
This change should help accessing header file from external packages present in our wasm prefix.

For example 

![image](https://github.com/user-attachments/assets/bae87f48-09b8-463b-9b94-200c71906198)
