### PR TITLE
Undo removal of archives for allowing kernels to link at runtime

### DIFF
--- a/config/empack_config.yaml
+++ b/config/empack_config.yaml
@@ -19,7 +19,6 @@ default:
     - pattern: '**/tests/**'
     - pattern: '**/*.ini'
     - pattern: '**/*.exe'
-    - pattern: '**/*.a'
     - pattern: '**/*.c'
     - pattern: '**/*.pxd'
     - pattern: '**/*.pyi'


### PR DESCRIPTION
For running an external library like symengine, the xeus-cpp kernel would have to link against libsymengine.a at runtime !
Hence we shouldn't be getting rid of archives for the same.

This was done if we link symengine during build time (before running the jupyterlite build when the filtering comes into play) but should be possible during runtime too !

![image](https://github.com/user-attachments/assets/db528a52-1122-4462-ba96-d5d2c2e8ad2a)
