### PR TITLE
Fix `TypeError` noticed in conda-forge release

### DIFF
--- a/empack/pack.py
+++ b/empack/pack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import os.path

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 from pathlib import Path, PosixPath, PureWindowsPath
 from tempfile import TemporaryDirectory
-from typing import Callable, Optional
+from typing import Callable
 
 from platformdirs import user_cache_dir
 
@@ -255,7 +255,7 @@ def pack_env(
     compression_format=ALLOWED_FORMATS[0],
     compresslevel=9,
     outdir=None,
-    package_url_factory: Optional[Callable] = None,
+    package_url_factory: Callable | None = None,
 ):
     with TemporaryDirectory() as tmp_dir:
         #  filter the complete environment


### PR DESCRIPTION
I guess this is what we need to fix the error noticed in https://github.com/conda-forge/empack-feedstock/pull/62?

~That said, I don't see why the error is being raised in the first place~, because it's using Python 3.12, which supports writing unions with `|` instead of having to use `Union[<...>, <...>]`

Ah, right, because Python 3.12 is just the conda-build driver version