### PR TITLE
Add "depends" to empack_env_meta.json

### DIFF
--- a/empack/filter_env.py
+++ b/empack/filter_env.py
@@ -51,6 +51,7 @@ def iterate_pip_pkg_record(env_prefix):
             build_number=0,
             channel="PyPi",
             depends=[],
+            subdir="",
         )
 
 
@@ -72,6 +73,7 @@ def write_minimal_conda_meta(pkg_meta, env_prefix):
     content = {k: pkg_meta[k] for k in ["name", "version", "build", "build_number", "channel"]}
     content["url"] = pkg_meta.get("url", None)
     content["depends"] = pkg_meta.get("depends", [])
+    content["subdir"] = pkg_meta.get("subdir", "")
     conda_meta_dir = Path(env_prefix) / "conda-meta"
     conda_meta_dir.mkdir(parents=True, exist_ok=True)
 

--- a/empack/filter_env.py
+++ b/empack/filter_env.py
@@ -71,6 +71,7 @@ def iterate_env_pkg_meta(env_prefix):
 def write_minimal_conda_meta(pkg_meta, env_prefix):
     content = {k: pkg_meta[k] for k in ["name", "version", "build", "build_number", "channel"]}
     content["url"] = pkg_meta.get("url", None)
+    content["depends"] = pkg_meta.get("depends", [])
     conda_meta_dir = Path(env_prefix) / "conda-meta"
     conda_meta_dir.mkdir(parents=True, exist_ok=True)
 

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -257,7 +257,6 @@ def pack_env(
     outdir=None,
     package_url_factory: Callable | None = None,
 ):
-
     with TemporaryDirectory() as tmp_dir:
         #  filter the complete environment
         filtered_prefix = Path(tmp_dir) / "filtered_env"

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -290,7 +290,8 @@ def pack_env(
                 filename_stem=base_fname,
                 filename=f"{base_fname}.tar.{compression_format}",
                 channel=pkg_meta["channel"],
-                depends=pkg_meta["depends"]
+                depends=pkg_meta["depends"],
+                subdir=pkg_meta["subdir"],
             )
 
             package_url = None

--- a/empack/pack.py
+++ b/empack/pack.py
@@ -257,6 +257,7 @@ def pack_env(
     outdir=None,
     package_url_factory: Callable | None = None,
 ):
+
     with TemporaryDirectory() as tmp_dir:
         #  filter the complete environment
         filtered_prefix = Path(tmp_dir) / "filtered_env"
@@ -289,6 +290,7 @@ def pack_env(
                 filename_stem=base_fname,
                 filename=f"{base_fname}.tar.{compression_format}",
                 channel=pkg_meta["channel"],
+                depends=pkg_meta["depends"]
             )
 
             package_url = None


### PR DESCRIPTION
We have the issue that we need to separate package dependencies from main packages which we pass to the js-rattler solver, but empack_env_meta.json file does not have any information about package dependencies. 

So the goal of this PR is to add this data to this file