### PR TITLE
Fix: Do not treat mount points as packages in the empack lock

### DIFF
--- a/empack/pack.py
+++ b/empack/pack.py
@@ -226,16 +226,20 @@ def add_tarfile_to_env_meta(env_meta_filename, tarfile):
 
     tarfile_name = Path(tarfile).name
     package_item = {"name": tarfile_name, "filename": tarfile_name}
+
+    if not env_meta["mounts"]:
+        env_meta["mounts"] = []
+
     # check that the package is not already in the list
-    for pkg in env_meta["packages"]:
+    for pkg in env_meta["mounts"]:
         if pkg["filename"] == tarfile_name:
-            msg = f"package with filename '{tarfile_name}' already in env meta file"
+            msg = f"mount point with filename '{tarfile_name}' already in env meta file"
             raise RuntimeError(msg)
         if pkg["name"] == package_item["name"]:
-            msg = f"package with name '{package_item['name']}' already in env meta file"
+            msg = f"mount point with name '{package_item['name']}' already in env meta file"
             raise RuntimeError(msg)
 
-    env_meta["packages"].append(package_item)
+    env_meta["mounts"].append(package_item)
     with open(env_meta_filename, "w") as f:
         json.dump(env_meta, f, indent=4)
 


### PR DESCRIPTION
This will help fixing https://github.com/jupyterlite/xeus/issues/237, issue noticed in practice in https://github.com/compiler-research/xeus-cpp/issues/357

This is a breaking change, we should make a major release with it